### PR TITLE
Implement LogoViewlet

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -2,3 +2,6 @@
 extends =
     test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+
+[versions]
+zc.buildout = 2.11.0

--- a/ftw/logo/browser/configure.zcml
+++ b/ftw/logo/browser/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser"
+  xmlns:plone="http://namespaces.plone.org/plone"
+  xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <browser:viewlet
+    name="plone.links.favicon"
+    class=".logo_viewlet.LogoViewlet"
+    permission="zope2.View"
+    manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
+    layer="ftw.logo.interfaces.IFtwLogo" />
+</configure>

--- a/ftw/logo/browser/logo_viewlet.pt
+++ b/ftw/logo/browser/logo_viewlet.pt
@@ -1,0 +1,15 @@
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.logo">
+
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="icon" href="/favicon.ico">
+<link rel="manifest" href="/manifest.json">
+<meta name="msapplication-config" content="/browserconfig.xml"/>
+<meta name="theme-color" content="#ffffff">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+</html>

--- a/ftw/logo/browser/logo_viewlet.py
+++ b/ftw/logo/browser/logo_viewlet.py
@@ -1,0 +1,7 @@
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class LogoViewlet(ViewletBase):
+
+    index = ViewPageTemplateFile('logo_viewlet.pt')

--- a/ftw/logo/configure.zcml
+++ b/ftw/logo/configure.zcml
@@ -7,6 +7,8 @@
 
     <five:registerPackage package="." initialize=".initialize" />
 
+    <include package=".browser" />
+
     <genericsetup:registerProfile
         name="default"
         title="ftw.logo default"
@@ -16,7 +18,7 @@
 
     <genericsetup:registerProfile
         name="uninstall"
-        title="ftw.logo : uninstall"
+        title="ftw.logo:uninstall"
         directory="profiles/uninstall"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"

--- a/ftw/logo/interfaces.py
+++ b/ftw/logo/interfaces.py
@@ -1,0 +1,6 @@
+from zope.interface import Interface
+
+
+class IFtwLogo(Interface):
+    """ftw.logo Browser Layer
+    """

--- a/ftw/logo/profiles/default/browserlayer.xml
+++ b/ftw/logo/profiles/default/browserlayer.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<layers>
+    <layer name="ftw.logo.layer"
+           interface="ftw.logo.interfaces.IFtwLogo" />
+</layers>

--- a/ftw/logo/profiles/uninstall/browserlayer.xml
+++ b/ftw/logo/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+    <layer name="ftw.logo.layer"
+           interface="ftw.logo.interfaces.IFtwLogo"
+           remove="True" />
+</layers>

--- a/ftw/logo/tests/test_viewlet.py
+++ b/ftw/logo/tests/test_viewlet.py
@@ -1,0 +1,72 @@
+from ftw.logo.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from unittest import skip
+
+
+class TestViewlet(FunctionalTestCase):
+
+    @skip("TODO: Remove defualt viewport from sunburst default template")
+    @browsing
+    def test_viewport_metatag(self, browser):
+        browser.login().visit(self.portal)
+
+        self.assertEqual(
+            ['width=device-width, initial-scale=1'],
+            map(lambda x: x.attrib['content'], browser.css(
+                'meta[name="viewport"]'))
+        )
+
+    @browsing
+    def test_logo_viewlet_displays_relevant_metadata_in_header(self, browser):
+        browser.login().visit(self.portal)
+
+        self.assertEqual(
+            [{'href': '/apple-touch-icon.png', 'sizes': '180x180'}],
+            map(lambda x: {
+                'href': x.attrib['href'],
+                'sizes': x.attrib['sizes'],
+            }, browser.css('link[rel="apple-touch-icon"]'))
+        )
+
+        self.assertEqual(
+            [
+                {
+                    'type': 'image/png',
+                    'sizes': '32x32',
+                    'href': '/favicon-32x32.png',
+                },
+                {
+                    'type': 'image/png',
+                    'sizes': '16x16',
+                    'href': '/favicon-16x16.png',
+                },
+                {
+                    'type': '',
+                    'sizes': '',
+                    'href': '/favicon.ico',
+                },
+            ],
+            map(lambda x: {
+                'type': x.attrib.get('type', ''),
+                'sizes': x.attrib.get('sizes', ''),
+                'href': x.attrib['href'],
+            }, browser.css('link[rel="icon"]'))
+        )
+
+        self.assertEqual(
+            ['/manifest.json'],
+            map(lambda x: x.attrib['href'], browser.css(
+                'link[rel="manifest"]'))
+        )
+
+        self.assertEqual(
+            ['/browserconfig.xml'],
+            map(lambda x: x.attrib['content'], browser.css(
+                'meta[name="msapplication-config"]'))
+        )
+
+        self.assertEqual(
+            ['#ffffff'],
+            map(lambda x: x.attrib['content'], browser.css(
+                'meta[name="theme-color"]'))
+        )


### PR DESCRIPTION
To not having the apple-touch-icon rendered twice
the viewlets overrides the plone default logo viewlet
and injects its own apple-touch-icon in the head.

Got the html template from https://realfavicongenerator.net