### PR TITLE
Implement image converter

### DIFF
--- a/ftw/logo/converter.py
+++ b/ftw/logo/converter.py
@@ -1,0 +1,64 @@
+from ftw.logo.image import Image
+
+
+def make_raw():
+    def raw(src):
+        return Image(src, 'svg')
+    return raw
+
+
+def make_resizer(width=0, height=0, extension='png'):
+    def resizer(src):
+        img = Image(src, extension)
+        img.sample(width, height)
+        return img
+    return resizer
+
+
+def make_transformer(width='', height='', extension='png'):
+    def transformer(src):
+        img = Image(src, extension)
+        img.transform(resize='{}x{}'.format(width, height))
+        return img
+    return transformer
+
+
+def make_ico_converter():
+    ICO_SCALES = [
+        make_resizer(16, 16),
+        make_resizer(32, 32),
+        make_resizer(48, 48),
+    ]
+
+    def converter(src):
+        scales = map(lambda resizer: resizer(src), ICO_SCALES)
+
+        def merge_scales(first, other):
+            first.append(other)
+            return first
+
+        ico = reduce(merge_scales, scales)
+
+        ico.format = 'ico'
+        return ico
+    return converter
+
+
+SCALES = {
+    'APPLE_TOUCH_ICON': make_resizer(180, 180),
+    'FAVICON_32X32':    make_resizer(32, 32),
+    'FAVICON_16X16':    make_resizer(16, 16),
+    'MSTILE_150X150':   make_resizer(150, 150),
+    'ANDROID_192X192':  make_resizer(192, 192),
+    'ANDROID_512X512':  make_resizer(512, 512),
+    'FAVICON':          make_ico_converter(),
+    'LOGO':             make_transformer(height=80),
+    'MOBILE_LOGO':      make_transformer(height=50),
+    'BASE':             make_raw(),
+}
+
+
+def convert(source, scale):
+    if scale not in SCALES:
+        raise Exception('scale: {} is not supported'.format(scale))
+    return SCALES[scale](source)

--- a/ftw/logo/image.py
+++ b/ftw/logo/image.py
@@ -1,0 +1,21 @@
+from wand.image import Image
+
+
+class Image(Image):
+
+    def __init__(self, filename, extension):
+        self.filename = filename
+        # behind format is a setter so the extension has to be kept seperately
+        self.extension = extension
+
+        super(Image, self).__init__(filename=self.filename)
+        self.format = self.extension
+
+    def make_blob(self):
+        # wand.py is not able to convert mvg to svg
+        if self.extension == 'svg':
+            return open(self.filename, 'r').read()
+        return super(Image, self).make_blob(self.extension)
+
+    def append(self, other):
+        self.sequence.append(other)

--- a/ftw/logo/tests/fixtures/logo.svg
+++ b/ftw/logo/tests/fixtures/logo.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1px" height="1px" viewBox="0 0 1 1" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="logo"></g>
+</svg>

--- a/ftw/logo/tests/test_converter.py
+++ b/ftw/logo/tests/test_converter.py
@@ -1,0 +1,56 @@
+from unittest2 import TestCase
+from ftw.testing import freeze
+from ftw.logo.converter import convert
+from datetime import datetime
+import os
+
+
+source = os.path.join(os.path.dirname(__file__), 'fixtures/logo.svg')
+
+
+class TestConverter(TestCase):
+
+    def assertImage(self, img, width, height, format=None, blob=None):
+        self.assertEqual(img.width, width)
+        self.assertEqual(img.height, height)
+        if format:
+            self.assertEqual(img.format.lower(), format.lower())
+        if blob:
+            self.assertEqual(img.make_blob(), blob)
+
+    def test_rejects_unsupported_types(self):
+        with self.assertRaises(Exception) as context:
+            convert(source, 'UNKNOWN')
+
+        self.assertTrue('scale: UNKNOWN is not supported' in context.exception)
+
+    def test_converts_svg_base(self):
+        self.assertImage(
+            convert(source, 'BASE'), 1, 1, 'svg',
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<svg width="1px" height="1px" viewBox="0 0 1 1" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n'
+            '    <g id="logo"></g>\n'
+            '</svg>\n'
+        )
+
+    def test_converts_png_fixed_size(self):
+        self.assertImage(
+            convert(source, 'APPLE_TOUCH_ICON'), 180, 180, 'png')
+
+    def test_converts_png_fixed_aspect_ratio(self):
+        self.assertImage(
+            convert(source, 'LOGO'), 80, 80, 'png')
+
+    def test_converts_multipart_images(self):
+        img = convert(source, 'FAVICON')
+        self.assertEqual(len(img.sequence), 3,
+                         'Should contain three subimages in the sequence')
+
+        self.assertImage(
+            img.sequence[0], 16, 16)
+
+        self.assertImage(
+            img.sequence[1], 32, 32)
+
+        self.assertImage(
+            img.sequence[2], 48, 48)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Plone',
         'setuptools',
         'ftw.upgrade',
+        'wand',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
The base image is an `svg` configured thru `.zcml`. The scales are then converted using wand.py which is a python wrapper around image magick.