### PR TITLE
Remove open file handlers from wand.py

### DIFF
--- a/ftw/logo/converter.py
+++ b/ftw/logo/converter.py
@@ -36,6 +36,7 @@ def make_ico_converter():
         def merge_scales(first, other):
             first.format = 'ico'
             first.append(other)
+            other.close()
             return first
 
         return reduce(merge_scales, scales)

--- a/ftw/logo/image.py
+++ b/ftw/logo/image.py
@@ -1,21 +1,39 @@
 from wand.image import Image
+import os
 
 
 class Image(Image):
 
-    def __init__(self, filename, extension):
-        self.filename = filename
-        # behind format is a setter so the extension has to be kept seperately
-        self.extension = extension
+    def __init__(self, filename, extension=None):
+        if not os.path.isfile(filename):
+            raise ValueError('{} could not be found'.format(filename))
 
+        self.filename = filename
         super(Image, self).__init__(filename=self.filename)
+
+        if extension is None:
+            filename, extension = os.path.splitext(filename)
+            # from pdb import set_trace; set_trace()
+            self.extension = extension.lstrip('.')
+        else:
+            self.extension = extension
+
+        # behind format is a setter so the extension has to be kept seperately
         self.format = self.extension
 
+        self._blob = None
+
     def make_blob(self):
+        if self._blob:
+            return self._blob
         # wand.py is not able to convert mvg to svg
         if self.extension == 'svg':
-            return open(self.filename, 'r').read()
-        return super(Image, self).make_blob(self.extension)
+            with open(self.filename, 'r') as f:
+                self._blob = f.read()
+        else:
+            self._blob = super(Image, self).make_blob(self.extension)
+        self.close()
+        return self._blob
 
     def append(self, other):
         self.sequence.append(other)

--- a/ftw/logo/tests/test_converter.py
+++ b/ftw/logo/tests/test_converter.py
@@ -54,3 +54,5 @@ class TestConverter(TestCase):
 
         self.assertImage(
             img.sequence[2], 48, 48)
+
+        img.close()


### PR DESCRIPTION
Some file handlers has not been properly closed when generating the scales.