### PR TITLE
No longer hand wand image objects around.

### DIFF
--- a/ftw/logo/browser/logo_view.py
+++ b/ftw/logo/browser/logo_view.py
@@ -45,9 +45,9 @@ class LogoView(BrowserView):
             (self.context, self.request), ILogo).get_config(self.config)
         scale = config.get_scale(self.scale)
         response = self.request.response
-        iterator = StringIOStreamIterator(scale.make_blob())
+        iterator = StringIOStreamIterator(scale['data'])
         contenttype = mimetypes.types_map.get('.{}'.format(
-            scale.extension), 'application/octet-stream')
+            scale['extension']), 'application/octet-stream')
         response.setHeader('X-Theme-Disabled', 'True')
         charset = '' if contenttype == 'application/octet-stream' else 'charset=utf-8'
         response.setHeader(

--- a/ftw/logo/converter.py
+++ b/ftw/logo/converter.py
@@ -72,4 +72,11 @@ def convert(source, scale):
     scales = flatten_scales(SCALES)
     if scale not in scales:
         raise Exception('scale: {} is not supported'.format(scale))
-    return scales[scale](source)
+    scale = scales[scale](source)
+    result = {'extension': scale.extension,
+              'width': scale.width,
+              'height': scale.height,
+              'format': scale.format,
+              'sequence_length': len(scale.sequence)}
+    result['data'] = scale.make_blob()  # closes scale as side effect
+    return result

--- a/ftw/logo/image.py
+++ b/ftw/logo/image.py
@@ -26,8 +26,12 @@ class Image(Image):
     def make_blob(self):
         if self._blob:
             return self._blob
-        # wand.py is not able to convert mvg to svg
         if self.extension == 'svg':
+            # If the target extension is svg, and we assume that the input data is also svg,
+            # we don't need to transform anything, but we can simply return the original data
+            # read from self.filename.
+            # self contains the image, but it is already converted to MVG, but we cannot
+            # convert it back to SVG. Therefore we need to read the original.
             with open(self.filename, 'r') as f:
                 self._blob = f.read()
         else:

--- a/ftw/logo/tests/test_collector.py
+++ b/ftw/logo/tests/test_collector.py
@@ -12,10 +12,10 @@ source = os.path.join(os.path.dirname(__file__), 'fixtures/logo.svg')
 class TestCollecter(TestCase):
 
     def assertImage(self, img, width, height, format=None):
-        self.assertEqual(img.width, width)
-        self.assertEqual(img.height, height)
+        self.assertEqual(img['width'], width)
+        self.assertEqual(img['height'], height)
         if format:
-            self.assertEqual(img.format.lower(), format.lower())
+            self.assertEqual(img['format'].lower(), format.lower())
 
     def test_all_logos_are_collected(self):
         component = LogoConfig(source)

--- a/ftw/logo/tests/test_converter.py
+++ b/ftw/logo/tests/test_converter.py
@@ -1,7 +1,5 @@
-from unittest2 import TestCase
-from ftw.testing import freeze
 from ftw.logo.converter import convert
-from datetime import datetime
+from unittest2 import TestCase
 import os
 
 
@@ -11,12 +9,12 @@ source = os.path.join(os.path.dirname(__file__), 'fixtures/logo.svg')
 class TestConverter(TestCase):
 
     def assertImage(self, img, width, height, format=None, blob=None):
-        self.assertEqual(img.width, width)
-        self.assertEqual(img.height, height)
+        self.assertEqual(img['width'], width)
+        self.assertEqual(img['height'], height)
         if format:
-            self.assertEqual(img.format.lower(), format.lower())
+            self.assertEqual(img['format'].lower(), format.lower())
         if blob:
-            self.assertEqual(img.make_blob(), blob)
+            self.assertEqual(img['data'], blob)
 
     def test_rejects_unsupported_types(self):
         with self.assertRaises(Exception) as context:
@@ -43,16 +41,5 @@ class TestConverter(TestCase):
 
     def test_converts_multipart_images(self):
         img = convert(source, 'FAVICON')
-        self.assertEqual(len(img.sequence), 3,
+        self.assertEqual(img['sequence_length'], 3,
                          'Should contain three subimages in the sequence')
-
-        self.assertImage(
-            img.sequence[0], 16, 16)
-
-        self.assertImage(
-            img.sequence[1], 32, 32)
-
-        self.assertImage(
-            img.sequence[2], 48, 48)
-
-        img.close()


### PR DESCRIPTION
The converter should not return any wand Image objects but only the resulting scale blob with metadata.

The wand Image objects should only be used while converting images and their scales. We do not want to store the full Image object, neither in RAM nor in the ZODB.

The converter now returns a simple dictionary with the blob data and metadata such as height, width, etc.