### PR TITLE
Implement a virtual scale called get_logo.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ The available scales are:
    - LOGO
    - MOBILE_LOGO
    - BASE
+   - get_logo (virtual)
 - ICONS
    - APPLE_TOUCH_ICON
    - FAVICON_32X32
@@ -90,6 +91,14 @@ The available scales are:
    - ANDROID_512X512
    - FAVICON
    - BASE
+
+
+"get_logo" scale
+--------------
+
+The get_logo virtual scale returns either the BASE (svg from ZCML) or if available the overridden
+BASE or LOGO scale from the Dexterity content type.
+
 
 Converter
 =========

--- a/ftw/logo/browser/logo_viewlet.pt
+++ b/ftw/logo/browser/logo_viewlet.pt
@@ -5,7 +5,7 @@
 
 <a tal:attributes="href view/navigation_root_url"
    id="portal-logo">
-   <img tal:attributes="src string:${view/navigation_root_url}/@@logo/logo/BASE?r=${view/cachekey}" />
+   <img tal:attributes="src string:${view/navigation_root_url}/@@logo/logo/get_logo?r=${view/cachekey}" />
 </a>
 
 <a tal:attributes="href view/navigation_root_url"

--- a/ftw/logo/tests/test_logo_view.py
+++ b/ftw/logo/tests/test_logo_view.py
@@ -7,6 +7,7 @@ from wand.image import Image
 
 source_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 custom = os.path.join(source_path, 'custom.svg')
+png = os.path.join(source_path, 'green.png')
 
 
 class TestLogoView(FunctionalTestCase):
@@ -62,3 +63,33 @@ class TestLogoView(FunctionalTestCase):
         self.assertNotEqual(
             before,
             after)
+
+    @browsing
+    def test_special_get_logo_scale_name_returns_svg_by_default(self, browser):
+        self.verify_image_format(browser, '@@logo/logo/get_logo', 'svg')
+        self.grant('Site Administrator')
+        browser.login().visit(self.portal, view='@@logo-and-icon-overrides')
+
+        with open(png) as green_png:
+            browser.fill({'Standard (desktop) logo (PNG)': green_png}).submit()
+            self.verify_image_format(browser, '@@logo/logo/get_logo', 'png')
+
+    @browsing
+    def test_special_get_logo_scale_name_returns_uploaded_png(self, browser):
+        self.verify_image_format(browser, '@@logo/logo/get_logo', 'svg')
+        self.grant('Site Administrator')
+        browser.login().visit(self.portal, view='@@logo-and-icon-overrides')
+
+        with open(png) as green_png:
+            browser.fill({'Standard (desktop) logo (PNG)': green_png}).submit()
+            self.verify_image_format(browser, '@@logo/logo/get_logo', 'png')
+
+    @browsing
+    def test_special_get_logo_scale_name_returns_uploaded_svg(self, browser):
+        self.verify_image_format(browser, '@@logo/logo/get_logo', 'svg')
+        self.grant('Site Administrator')
+        browser.login().visit(self.portal, view='@@logo-and-icon-overrides')
+
+        with open(png) as green_png:
+            browser.fill({'Standard (desktop) logo (PNG)': green_png}).submit()
+            self.verify_image_format(browser, '@@logo/logo/get_logo', 'png')

--- a/ftw/logo/tests/test_logo_viewlet.py
+++ b/ftw/logo/tests/test_logo_viewlet.py
@@ -17,7 +17,7 @@ class TestLogoViewlet(FunctionalTestCase):
 
         self.assertEqual(
             map(lambda x: x.attrib['src'], browser.css('#portal-logo > img')),
-            ['http://nohost/plone/@@logo/logo/BASE?r={}'.format(etag)],
+            ['http://nohost/plone/@@logo/logo/get_logo?r={}'.format(etag)],
         )
 
     @browsing


### PR DESCRIPTION
The get_logo virtual scale returns either the BASE (svg from ZCML) or if available the overridden
BASE or LOGO scale from the Dexterity content type.


Use-Case:
Imagine you got a new logo (only png) and you upload it using ftw.logo. 
This way the new logo is used, before the BASE was always displayed. 