### PR TITLE
Add plone5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Compatibility
 -------------
 
 Plone 4.3.x
+Plone 5.1.x
 
 Prerequisites
 =============

--- a/development.cfg
+++ b/development.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,4 +5,5 @@ Changelog
 1.0.0 (unreleased)
 --------------------
 
+- Add Plone 5.1 support. [busykoala]
 - Initial implementation.

--- a/ftw/logo/configure.zcml
+++ b/ftw/logo/configure.zcml
@@ -18,9 +18,18 @@
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="default"
         title="ftw.logo default"
         directory="profiles/default"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="default"
+        title="ftw.logo default"
+        directory="profiles/default_plone5"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
@@ -32,9 +41,19 @@
         />
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="uninstall"
         title="ftw.logo:uninstall"
         directory="profiles/uninstall"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="uninstall"
+        title="ftw.logo:uninstall"
+        directory="profiles/uninstall_plone5"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />

--- a/ftw/logo/logo.py
+++ b/ftw/logo/logo.py
@@ -5,16 +5,16 @@ from ftw.logo.manual_override import BLOB_CACHEKEY
 from ftw.logo.manual_override import OVERRIDES_FIXED_ID
 from hashlib import sha256
 from plone.app.caching.interfaces import IETagValue
-from Products.CMFPlone.interfaces import IPloneSiteRoot
+from plone.app.layout.navigation.interfaces import INavigationRoot
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.component import getMultiAdapter
-from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import implementer
 
 
 @implementer(ILogo)
-@adapter(IPloneSiteRoot, Interface)
+@adapter(INavigationRoot, Interface)
 class Logo(object):
 
     def __init__(self, context, request):

--- a/ftw/logo/profiles/default_plone5/actions.xml
+++ b/ftw/logo/profiles/default_plone5/actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <object name="user" meta_type="CMF Action Category">
+  <object name="override_logos" meta_type="CMF Action" i18n:domain="ftw.logo">
+   <property name="title" i18n:translate="">Override Site Logos</property>
+   <property name="description" i18n:translate=""></property>
+   <property
+      name="url_expr">string:${globals_view/navigationRootUrl}/logo-and-icon-overrides</property>
+   <property name="link_target"></property>
+   <property name="icon_expr"></property>
+   <property
+      name="available_expr">python:plone_context_state.canonical_object() == plone_portal_state.navigation_root()</property>
+   <property name="permissions">
+    <element value="ftw.logo.OverrideSiteLogosAndIcons"/>
+   </property>
+   <property name="visible">True</property>
+  </object>
+ </object>
+</object>

--- a/ftw/logo/profiles/default_plone5/browserlayer.xml
+++ b/ftw/logo/profiles/default_plone5/browserlayer.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<layers>
+    <layer name="ftw.logo.layer"
+           interface="ftw.logo.interfaces.IFtwLogo" />
+</layers>

--- a/ftw/logo/profiles/default_plone5/metadata.xml
+++ b/ftw/logo/profiles/default_plone5/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-ftw.upgrade:default</dependency>
+        <dependency>profile-ftw.theming:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/logo/profiles/default_plone5/rolemap.xml
+++ b/ftw/logo/profiles/default_plone5/rolemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.logo: Override site logos and icons" acquire="False">
+      <role name="Site Administrator" />
+      <role name="Manager" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/logo/profiles/default_plone5/types.xml
+++ b/ftw/logo/profiles/default_plone5/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types">
+  <object name="ftw.logo.ManualOverrides" meta_type="Dexterity FTI" />
+</object>

--- a/ftw/logo/profiles/default_plone5/types/ftw.logo.ManualOverrides.xml
+++ b/ftw/logo/profiles/default_plone5/types/ftw.logo.ManualOverrides.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object name="ftw.logo.ManualOverrides" meta_type="Dexterity FTI" i18n:domain="ftw.logo"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="title" i18n:translate="">Manual Overrides</property>
+  <property name="description"
+    i18n:translate="">Manual icon and logo overrides for ftw.logo</property>
+
+  <property name="icon_expr">string:${portal_url}/image_icon.png</property>
+
+  <property name="factory">ftw.logo.ManualOverrides</property>
+
+  <property name="add_view_expr">string:${folder_url}/++add++ftw.logo.ManualOverrides</property>
+
+  <property name="link_target"></property>
+  <property name="immediate_view">view</property>
+
+  <property name="global_allow">False</property>
+
+  <property name="allow_discussion">False</property>
+
+  <property name="default_view">view</property>
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+  <property name="default_view_fallback">False</property>
+
+  <property name="add_permission">ftw.logo.OverrideSiteLogosAndIcons</property>
+
+  <property name="klass">plone.dexterity.content.Item</property>
+
+  <property name="behaviors">
+  </property>
+
+  <property name="schema">ftw.logo.manual_override.IManualOverrides</property>
+
+  <alias from="(Default)" to="view"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="(selected layout)"/>
+  <action title="View" action_id="view" category="object" condition_expr=""
+    description="" icon_expr="" link_target="" url_expr="string:${object_url}"
+    visible="True">
+    <permission value="View"/>
+  </action>
+  <action title="Edit" action_id="edit" category="object" condition_expr=""
+    description="" icon_expr="" link_target=""
+    url_expr="string:${object_url}/edit" visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+</object>

--- a/ftw/logo/profiles/default_plone5/workflows.xml
+++ b/ftw/logo/profiles/default_plone5/workflows.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <bindings purge="False">
+  <type type_id="ftw.logo.ManualOverrides">
+   <bound-workflow workflow_id="one_state_workflow"/>
+  </type>
+ </bindings>
+</object>

--- a/ftw/logo/profiles/uninstall_plone5/actions.xml
+++ b/ftw/logo/profiles/uninstall_plone5/actions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <object name="user" meta_type="CMF Action Category">
+  <object name="override_logos" remove="true" />
+ </object>
+</object>

--- a/ftw/logo/profiles/uninstall_plone5/browserlayer.xml
+++ b/ftw/logo/profiles/uninstall_plone5/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+    <layer name="ftw.logo.layer"
+           interface="ftw.logo.interfaces.IFtwLogo"
+           remove="True" />
+</layers>

--- a/ftw/logo/profiles/uninstall_plone5/rolemap.xml
+++ b/ftw/logo/profiles/uninstall_plone5/rolemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.logo: Override site logos and icons" acquire="True">
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/logo/profiles/uninstall_plone5/types.xml
+++ b/ftw/logo/profiles/uninstall_plone5/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types">
+  <object name="ftw.logo.ManualOverrides" meta_type="Dexterity FTI" remove="True" />
+</object>

--- a/ftw/logo/profiles/uninstall_plone5/workflows.xml
+++ b/ftw/logo/profiles/uninstall_plone5/workflows.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <bindings purge="False">
+  <type type_id="ftw.logo.ManualOverrides" remove="True">
+   <bound-workflow workflow_id="one_state_workflow"/>
+  </type>
+ </bindings>
+</object>

--- a/ftw/logo/testing.py
+++ b/ftw/logo/testing.py
@@ -1,16 +1,18 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from ftw.testing import IS_PLONE_5
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.testing.layer import ComponentRegistryLayer
-import os
 from plone.app.caching.interfaces import IETagValue
-from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile
 from plone.testing import z2
 from zope.component import getMultiAdapter
 from zope.configuration import xmlconfig
+import os
+
 
 source_path = os.path.join(os.path.dirname(__file__), 'tests', 'fixtures')
 blue_svg = os.path.join(source_path, 'blue.svg')
@@ -71,6 +73,9 @@ class BlueBaseLogoLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.logo:default')
+
+        if IS_PLONE_5:
+            applyProfile(portal, 'plone.app.contenttypes:default')
 
 
 BLUE_BASE_LOGO_FIXTURE = BlueBaseLogoLayer()

--- a/ftw/logo/tests/test_icon_viewlet.py
+++ b/ftw/logo/tests/test_icon_viewlet.py
@@ -1,7 +1,9 @@
 from ftw.logo.testing import get_etag_value_for
 from ftw.logo.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
+from ftw.testing import IS_PLONE_5
 from unittest import skip
+from unittest2 import skipIf
 
 
 class TestIconViewlet(FunctionalTestCase):
@@ -17,8 +19,9 @@ class TestIconViewlet(FunctionalTestCase):
                 'meta[name="viewport"]'))
         )
 
+    @skipIf(IS_PLONE_5, 'The apple touch logo is not configurable in plone5')
     @browsing
-    def test_logo_viewlet_displays_relevant_metadata_in_header(self, browser):
+    def test_logo_viewlet_displays_relevant_metadata_in_header_part_one(self, browser):
         etag = get_etag_value_for(self.portal, self.request)
         browser.login().visit(self.portal)
 
@@ -31,6 +34,11 @@ class TestIconViewlet(FunctionalTestCase):
                 'sizes': x.attrib['sizes'],
             }, browser.css('link[rel="apple-touch-icon"]'))
         )
+
+    @browsing
+    def test_logo_viewlet_displays_relevant_metadata_in_header_part_two(self, browser):
+        etag = get_etag_value_for(self.portal, self.request)
+        browser.login().visit(self.portal)
 
         self.assertEqual(
             [

--- a/ftw/logo/tests/test_manual_overrides.py
+++ b/ftw/logo/tests/test_manual_overrides.py
@@ -13,8 +13,6 @@ from zope.annotation.interfaces import IAnnotations
 import os
 
 
-GREEN = '#0f0'
-
 source_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 blue_svg = os.path.join(source_path, 'blue.svg')
 red_svg = os.path.join(source_path, 'red.svg')
@@ -103,31 +101,41 @@ class TestManualOverrides(FunctionalTestCase):
             browser.fill({'SVG base logo': svg_file}).submit()
 
         # Check SVG image is set
-        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg', 'red')
+        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg',
+                                  'rgba(255,0,0,1)')
         # Check conversion to PNG
-        img = self.verify_correct_image(browser, '@@logo/logo/MOBILE_LOGO', 'png', 'red')
+        img = self.verify_correct_image(browser, '@@logo/logo/MOBILE_LOGO',
+                                        'png', 'rgba(255,0,0,1)')
         self.assertEqual(50, img.height)
         # Check ZCML 'bypass' - base SVG should be shown
-        img = self.verify_correct_image(browser, '@@logo/z/logo/MOBILE_LOGO', 'png', 'blue')
+        img = self.verify_correct_image(browser, '@@logo/z/logo/MOBILE_LOGO',
+                                        'png', 'rgba(0,0,255,1)')
         self.assertEqual(50, img.height)
 
         # verify icons are unaffected (i.e. still derive from base icon)
-        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg', 'blue')
-        self.verify_correct_image(browser, '@@logo/icon/ANDROID_192X192', 'png', 'blue')
-
-        # Test PNG override (Note: we don't test dimensions as they are not enforced)
+        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg',
+                                  'rgba(0,0,255,1)')
+        self.verify_correct_image(browser, '@@logo/icon/ANDROID_192X192',
+                                  'png', 'rgba(0,0,255,1)')
+        # Test PNG override
+        # (Note: we don't test dimensions as they are not enforced)
         overrides = self.portal[OVERRIDES_FIXED_ID]
         browser.login().visit(overrides, view='@@edit')
         with open(green_png) as png_file:
             browser.fill({'Mobile logo (PNG)': png_file}).submit()
-        self.verify_correct_image(browser, '@@logo/logo/MOBILE_LOGO', 'png', GREEN)
+
+        self.verify_correct_image(browser, '@@logo/logo/MOBILE_LOGO', 'png',
+                                  'rgba(0,255,0,1)')
 
         # Check ZCML 'bypass' - a scale of the base SVG should be shown
-        self.verify_correct_image(browser, '@@logo/z/logo/MOBILE_LOGO', 'png', 'blue')
+        self.verify_correct_image(browser, '@@logo/z/logo/MOBILE_LOGO', 'png',
+                                  'rgba(0,0,255,1)')
 
         # verify icons are unaffected (i.e. still derive from base icon)
-        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg', 'blue')
-        self.verify_correct_image(browser, '@@logo/icon/ANDROID_192X192', 'png', 'blue')
+        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg',
+                                  'rgba(0,0,255,1)')
+        self.verify_correct_image(browser, '@@logo/icon/ANDROID_192X192',
+                                  'png', 'rgba(0,0,255,1)')
 
     @browsing
     def test_icon_overrides(self, browser):
@@ -140,33 +148,42 @@ class TestManualOverrides(FunctionalTestCase):
             browser.fill({'SVG base icon': svg_file}).submit()
 
         # Check SVG image is set
-        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg', 'red')
+        self.verify_correct_image(browser, '@@logo/icon/BASE', 'svg',
+                                  'rgba(255,0,0,1)')
         # Check conversion to PNG
-        img = self.verify_correct_image(browser, '@@logo/icon/FAVICON_32X32', 'png', 'red')
+        img = self.verify_correct_image(browser, '@@logo/icon/FAVICON_32X32',
+                                        'png', 'rgba(255,0,0,1)')
         self.assertEqual(32, img.height)
         self.assertEqual(32, img.width)
         # Check ZCML 'bypass' - a scale of the base SVG should be shown
-        img = self.verify_correct_image(browser, '@@logo/z/icon/FAVICON_32X32', 'png', 'blue')
+        img = self.verify_correct_image(browser, '@@logo/z/icon/FAVICON_32X32',
+                                        'png', 'rgba(0,0,255,1)')
         self.assertEqual(32, img.height)
         self.assertEqual(32, img.width)
 
         # verify logos are unaffected (i.e. still derive from base logo)
-        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg', 'blue')
-        self.verify_correct_image(browser, '@@logo/logo/LOGO', 'png', 'blue')
+        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg',
+                                  'rgba(0,0,255,1)')
+        self.verify_correct_image(browser, '@@logo/logo/LOGO', 'png',
+                                  'rgba(0,0,255,1)')
 
         # Test PNG override (Note: we don't test dimensions as they are not enforced)
         overrides = self.portal[OVERRIDES_FIXED_ID]
         browser.login().visit(overrides, view='@@edit')
         with open(green_png) as png_file:
             browser.fill({'Favicon 32x32': png_file}).submit()
-        self.verify_correct_image(browser, '@@logo/icon/FAVICON_32X32', 'png', GREEN)
+        self.verify_correct_image(browser, '@@logo/icon/FAVICON_32X32', 'png',
+                                  'rgba(0,255,0,1)')
 
         # Check ZCML 'bypass' - base SVG should be shown
-        self.verify_correct_image(browser, '@@logo/z/icon/FAVICON_32X32', 'png', 'blue')
+        self.verify_correct_image(browser, '@@logo/z/icon/FAVICON_32X32',
+                                  'png', 'rgba(0,0,255,1)')
 
         # verify logos are unaffected (i.e. still derive from base logo)
-        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg', 'blue')
-        self.verify_correct_image(browser, '@@logo/logo/LOGO', 'png', 'blue')
+        self.verify_correct_image(browser, '@@logo/logo/BASE', 'svg',
+                                  'rgba(0,0,255,1)')
+        self.verify_correct_image(browser, '@@logo/logo/LOGO', 'png',
+                                  'rgba(0,0,255,1)')
 
     @browsing
     def test_form_validation(self, browser):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     classifiers=[
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+    sources.cfg
+
+package-name = ftw.logo


### PR DESCRIPTION
__Changes:__

- Changelog entry
- Readme update (plone 5 support)
- Setup.py entry for plone 5 (pypi search)
- Plone 5 profile
- Apple touch logo is not configurable in plone 5 therefore we skip the test.
- The wand package has system dependencies sometimes creating an image with RGB color key and sometimes havin RGBA color key. So that both pass I try the two possibilities.