### PR TITLE
Fix the user action "Override Site Logos".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the user action "Override Site Logos". [mbaechtold]
 
 
 1.0.2 (2019-07-05)

--- a/ftw/logo/profiles/default/actions.xml
+++ b/ftw/logo/profiles/default/actions.xml
@@ -12,7 +12,7 @@
    <property
       name="available_expr">python:plone_context_state.canonical_object() == plone_portal_state.navigation_root()</property>
    <property name="permissions">
-    <element value="ftw.logo.OverrideSiteLogosAndIcons"/>
+    <element value="ftw.logo: Override site logos and icons"/>
    </property>
    <property name="visible">True</property>
   </object>

--- a/ftw/logo/profiles/default_plone5/actions.xml
+++ b/ftw/logo/profiles/default_plone5/actions.xml
@@ -12,7 +12,7 @@
    <property
       name="available_expr">python:plone_context_state.canonical_object() == plone_portal_state.navigation_root()</property>
    <property name="permissions">
-    <element value="ftw.logo.OverrideSiteLogosAndIcons"/>
+    <element value="ftw.logo: Override site logos and icons"/>
    </property>
    <property name="visible">True</property>
   </object>

--- a/ftw/logo/tests/test_action.py
+++ b/ftw/logo/tests/test_action.py
@@ -1,0 +1,15 @@
+from ftw.testbrowser import browsing
+
+from ftw.logo.tests import FunctionalTestCase
+
+
+class TestAction(FunctionalTestCase):
+
+    @browsing
+    def test_action(self, browser):
+        self.grant("Site Administrator")  # See "rolemap.xml".
+        browser.login().visit(self.portal)
+        self.assertEqual(
+            "http://nohost/plone/logo-and-icon-overrides",
+            browser.find("Override Site Logos").attrib["href"],
+        )


### PR DESCRIPTION
The user action "Override Site Logos" did not show up due to a misconfigured Plone action.