### PR TITLE
Fix test failure because of same file used twice.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix user action permission. [mathias.leimgruber]
+- Fix test using the same file twice. [busykoala]
 
 
 1.0.2 (2019-07-05)

--- a/ftw/logo/tests/test_manual_overrides.py
+++ b/ftw/logo/tests/test_manual_overrides.py
@@ -224,9 +224,10 @@ class TestManualOverrides(FunctionalTestCase):
 
         # add some overrides
         browser.login().visit(self.portal, view='@@logo-and-icon-overrides')
-        with open(red_svg) as svg_file:
-            browser.fill({'SVG base logo': svg_file,
-                          'SVG base icon': svg_file}).submit()
+        with open(red_svg) as svg_file1:
+            with open(red_svg) as svg_file2:
+                browser.fill({'SVG base logo': svg_file1,
+                              'SVG base icon': svg_file2}).submit()
 
         # Check we have some annotations
         override_obj = self.portal[OVERRIDES_FIXED_ID]


### PR DESCRIPTION
The same file was used twice in this test. Now using a context manager for each file we have two different file instances.

Close https://github.com/4teamwork/ogb/issues/113